### PR TITLE
fix to avoid overwritten by custom settings

### DIFF
--- a/plugin/black-macchiato.vim
+++ b/plugin/black-macchiato.vim
@@ -1,7 +1,5 @@
-let g:black_macchiato_path = "black-macchiato"
-
 function s:RunBlackMacchiato() range
-    let cmd = g:black_macchiato_path
+    let cmd = get(g:, "black_macchiato_path", "black-macchiato")
     if !executable(cmd)
         echohl ErrorMsg
         echom "black-macchiato not found!"


### PR DESCRIPTION
## Summary

This PR fixed the problem that black macchiato path is overwritten by the plugin, even though I set it to the other value in my `init.vim`.

## Related Issue

https://github.com/smbl64/vim-black-macchiato/issues/1