### PR TITLE
Fix error for selection

### DIFF
--- a/plugin/black-macchiato.vim
+++ b/plugin/black-macchiato.vim
@@ -17,5 +17,5 @@ endfunction
 " Create a command to call the black-macchiato function
 command -range BlackMacchiato <line1>,<line2>call <sid>RunBlackMacchiato()
 
-xnoremap <plug>(BlackMacchiatoSelection) :'<,'>BlackMacchiato<cr>
+xnoremap <plug>(BlackMacchiatoSelection) :BlackMacchiato<cr>
 nnoremap <plug>(BlackMacchiatoCurrentLine) :BlackMacchiato<cr>


### PR DESCRIPTION
Without this, I would get an error when selecting text and using the documented keybinding in the README

    E492: Not an editor command: '<,'>'<,'>BlackMacchiato